### PR TITLE
fix(scripts): branch-summary leaving out trailer looking end section

### DIFF
--- a/scripts/scripts/src/commit_messages.rs
+++ b/scripts/scripts/src/commit_messages.rs
@@ -85,15 +85,17 @@ fn commit_as_markdown(
     result_lines: &mut Vec<String>,
     commit: &Commit<'_>,
 ) -> Result<(), gix::object::commit::Error> {
-    let first_line = commit.message()?.summary();
-    let body = commit.message()?.body();
+    let message = commit.message_raw_sloppy().to_string();
+    let mut lines = message.lines();
+    if let Some(first_line) = lines.next() {
+        result_lines.push(format!("# {}", first_line));
 
-    result_lines.push(format!("# {}", first_line));
-    result_lines.push("".to_string());
+        let next = lines.next().unwrap_or("");
+        result_lines.push(next.to_string());
 
-    if let Some(body_text) = body {
-        result_lines.push(body_text.to_string());
-        result_lines.push("".to_string());
+        lines.for_each(|line| {
+            result_lines.push(line.to_string());
+        });
     }
 
     Ok(())

--- a/scripts/scripts/tests/mika_tests.rs
+++ b/scripts/scripts/tests/mika_tests.rs
@@ -79,3 +79,47 @@ fn test_get_commit_messages_on_current_branch() -> Result<(), Box<dyn std::error
 
     Ok(())
 }
+
+#[test]
+fn test_include_codeblock_at_end() -> Result<(), Box<dyn std::error::Error>> {
+    let context = TestRepoBuilder::new()?;
+    context.commit("initial commit")?;
+
+    context.checkout("feature")?;
+
+    context.commit(
+        &[
+            "feat: update openapi from 1.4.3 to 1.4.5",
+            "",
+            "I verified that the test environment api does accept `phoneNumber` to be",
+            "`undefined` by doing the following.",
+            "",
+            "```ts",
+            "const response = await Service.patchApiData({",
+            "  path: { id: 100 },",
+            "})",
+            "```",
+        ]
+        .join("\n"),
+    )?;
+
+    let lines = get_commit_messages_on_current_branch(&context.repo)?;
+
+    assert_eq!(
+        lines,
+        vec![
+            "# feat: update openapi from 1.4.3 to 1.4.5",
+            "",
+            "I verified that the test environment api does accept `phoneNumber` to be",
+            "`undefined` by doing the following.",
+            "",
+            "```ts",
+            "const response = await Service.patchApiData({",
+            "  path: { id: 100 },",
+            "})",
+            "```"
+        ],
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Git has a concept called trailers:
https://git-scm.com/docs/git-interpret-trailers

If a code block was included in the commit message, it could be interpreted as a trailer if a line in it looked like a trailer. In this case, the code block was not included in the commit message at all.