### PR TITLE
fix(scripts): always add empty lines between commit messages

### DIFF
--- a/scripts/scripts/src/commit_messages.rs
+++ b/scripts/scripts/src/commit_messages.rs
@@ -21,6 +21,7 @@ pub fn get_commit_messages_between_commits(
         }
         let commit = repo.find_commit(commit.id)?;
         commit_as_markdown(&mut result_lines, &commit)?;
+        result_lines.push("".to_string()); // Add an empty line between commits
     }
 
     Ok(result_lines)
@@ -76,6 +77,7 @@ pub fn get_commit_messages_on_branch<S: AsRef<str> + std::fmt::Display>(
             .find_commit(commit.id)
             .context(format!("failed to find the commit {}", commit.id))?;
         commit_as_markdown(&mut results, &commit)?;
+        results.push("".to_string()); // Add an empty line between commits
     }
 
     Ok(results)
@@ -89,9 +91,6 @@ fn commit_as_markdown(
     let mut lines = message.lines();
     if let Some(first_line) = lines.next() {
         result_lines.push(format!("# {}", first_line));
-
-        let next = lines.next().unwrap_or("");
-        result_lines.push(next.to_string());
 
         lines.for_each(|line| {
             result_lines.push(line.to_string());

--- a/scripts/scripts/tests/mika_tests.rs
+++ b/scripts/scripts/tests/mika_tests.rs
@@ -37,7 +37,15 @@ fn test_get_commit_messages_on_branch() -> Result<(), Box<dyn std::error::Error>
     context.checkout("feature")?;
 
     context.commit("feat: feature commit 1")?;
-    context.commit("feat: feature commit 2")?;
+    context.commit(
+        &[
+            "feat: feature commit 2",
+            "",
+            "This commit is on the feature branch.",
+        ]
+        .join("\n")
+        .to_string(),
+    )?;
     context.commit("feat: feature commit 3")?;
 
     let lines = get_commit_messages_on_branch(&context.repo, "feature")?;
@@ -48,6 +56,8 @@ fn test_get_commit_messages_on_branch() -> Result<(), Box<dyn std::error::Error>
             "# feat: feature commit 3",
             "",
             "# feat: feature commit 2",
+            "",
+            "This commit is on the feature branch.",
             "",
             "# feat: feature commit 1",
             "",
@@ -117,7 +127,8 @@ fn test_include_codeblock_at_end() -> Result<(), Box<dyn std::error::Error>> {
             "const response = await Service.patchApiData({",
             "  path: { id: 100 },",
             "})",
-            "```"
+            "```",
+            ""
         ],
     );
 


### PR DESCRIPTION
This fixes a bug where a multiline commit message would not have an empty line after it.