### PR TITLE
chore(rust): add rust-toolchain and update rust version w/ dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,8 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "rust-toolchain"
+    directory: "/scripts/"
+    schedule:
+      interval: "weekly"

--- a/scripts/rust-toolchain.toml
+++ b/scripts/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/