### PR TITLE
refactor(ci): constrain permissions for GITHUB_TOKEN in linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,6 @@
 name: Linting
-
+permissions:
+  contents: read
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
https://github.com/mikavilpas/yazi.nvim/pull/1208#pullrequestreview-3237227226

---

Check warning Code scanning / CodeQL

Workflow does not contain permissions Medium

Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read} Show more details Dismiss alert Copilot Autofix AI 4 minutes ago

To fix this issue, add a top-level permissions block to limit the default permissions granted to the GITHUB_TOKEN for all jobs in the workflow. In this case, the minimal required permission is typically contents: read unless a job requires more. Based on the shown actions (checkout, linters), contents: read should be sufficient. The fix is to add:

```yaml
permissions:
  contents: read
```

directly under the workflow name: and above the on: key (usually line 2 or 3 in the file). No changes to individual jobs are required unless they need elevated permissions.