### PR TITLE
refactor(ci): use stow first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,19 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install GNU stow and setup the dotfiles
+        run: |
+          sudo apt-get install stow tree
+          pwd
+          ls -la
+          echo "Installing dotfiles to HOME $HOME"
+          stow --verbose 2 . --target="$HOME"
+          echo "Installed dotfiles to HOME $HOME"
+          echo "List files in HOME"
+          ls -la ~/
+          echo "List files in ~/.config"
+          ls -la ~/.config/
+
       - name: Install the fish shell
         run: |
           sudo apt-add-repository ppa:fish-shell/release-4
@@ -45,19 +58,6 @@ jobs:
       - name: Build
         run: cargo install --locked --path scripts/
         working-directory: scripts
-
-      - name: Install GNU stow and setup the dotfiles
-        run: |
-          sudo apt-get install stow tree
-          pwd
-          ls -la
-          echo "Installing dotfiles to HOME $HOME"
-          stow --verbose 2 . --target="$HOME"
-          echo "Installed dotfiles to HOME $HOME"
-          echo "List files in HOME"
-          ls -la ~/
-          echo "List files in ~/.config"
-          ls -la ~/.config/
 
       - name: Install delta
         run: |


### PR DESCRIPTION
I came up with a new pattern for automatically updating shell completion scripts when mise tools are updated

Trying to avoid this kind of conflict when stowing:

```rust
Planning stow of package .... done
WARNING! stowing . would cause conflicts:
  * existing target is neither a link nor a directory: .config/fish/completions/xh.fish
All operations aborted.
```