### PR TITLE
ci: stylua always uses the latest version

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -33,6 +33,6 @@ jobs:
       - uses: JohnnyMorganz/stylua-action@v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.0.2
+          version: latest
           # CLI arguments
           args: --color always --check .


### PR DESCRIPTION
Renovate updates the stylua version asap anyway, so we might as well always use the latest version.