### PR TITLE
chore: pin assert_cmd dependency version in scripts/Cargo.toml

### DIFF
--- a/scripts/scripts/Cargo.toml
+++ b/scripts/scripts/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = { workspace = true }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }
-assert_cmd = "2.0.17"
+assert_cmd = "=2.0.17"
 
 [build-dependencies]
 clap = { version = "4.5.47", features = ["derive"] }


### PR DESCRIPTION
The highlighted change modifies the way the `assert_cmd` dependency version is specified in the `Cargo.toml` file:

**Before:**

```toml
assert_cmd = "2.0.17"
```

**After:**

```toml
assert_cmd = "=2.0.17"
```

**Explanation:**

- `"2.0.17"` allows Cargo to use version `2.0.17` or any compatible updates (i.e., `2.0.x` as per [semver](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio)).
- `"=2.0.17"` restricts Cargo to use **exactly** version `2.0.17`—no other patch, minor, or major version will be accepted.

**Context:**
This change makes the dependency version stricter, ensuring that the project will only build with exactly `assert_cmd` version `2.0.17`. This can help prevent unexpected build or runtime issues due to changes in newer patch releases.