### PR TITLE
ci(mise): remove explicitly disabling tools

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,4 +1,3 @@
-settings.disable_tools = ["node"]
 settings.cargo.binstall = true
 
 # Pick tools that renovate can manage updates for. See:

--- a/.mise.ci.toml
+++ b/.mise.ci.toml
@@ -1,1 +1,0 @@
-settings.disable_tools = ["node", "delta"]


### PR DESCRIPTION
The tools are now disabled by default in the new mise version: https://github.com/jdx/mise/pull/6501