### PR TITLE
ci: bypass apt issues installing fish shell with mise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,6 @@ jobs:
           echo "List files in ~/.config"
           ls -la ~/.config/
 
-      - name: Install the fish shell
-        run: |
-          sudo apt-add-repository ppa:fish-shell/release-4
-          sudo apt update
-          sudo apt install fish
-          echo "Installed fish version $(fish --version)"
-
       - name: Setup the mold linker
         uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
@@ -53,7 +46,29 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
-      - name: Install tools with UBI
+      - name: Read mise version from config
+        id: mise-version
+        shell: bash
+        run: |
+          VERSION=$(yq '.tools."aqua:jdx/mise"' .config/mise/config.toml)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install tools with mise
+        uses: jdx/mise-action@v4.0.1
+        env:
+          # mise's `auto_install` etc. cause activation/exec to install every
+          # tool in the trusted config. Disable so only `install_args` is honored.
+          MISE_AUTO_INSTALL: "false"
+          MISE_EXEC_AUTO_INSTALL: "false"
+          MISE_NOT_FOUND_AUTO_INSTALL: "false"
+        with:
+          version: ${{ steps.mise-version.outputs.version }}
+          # prettier-ignore
+          install_args: >-
+            aqua:fish-shell/fish-shell
+            github:dandavison/delta
+
+      - name: Install lazygit with UBI
         shell: bash
         run: |
           mkdir -p "$HOME/.local/bin"
@@ -63,11 +78,6 @@ jobs:
               "https://raw.githubusercontent.com/houseabsolute/ubi/${UBI_VERSION}/bootstrap/bootstrap-ubi.sh" |
               TARGET="$HOME/.local/bin" sh
 
-          VERSION=$(yq '.tools.yq.version' .config/mise/config.toml)
-          ubi --project mikefarah/yq --tag "v$VERSION"
-
-          VERSION=$(yq '.tools."github:dandavison/delta"' .config/mise/config.toml)
-          ubi --project dandavison/delta --tag "$VERSION"
           ubi --project jesseduffield/lazygit --tag "${LAZYGIT_VERSION}"
 
           ls -alR bin


### PR DESCRIPTION
The build is currently failing due to issues with `apt` when trying to install the `fish` shell.
https://github.com/mikavilpas/dotfiles/actions/runs/25241068997/job/74028690071

Try to work around it by using mise.