### PR TITLE
ci(test-mise): disable mise cache to fix zizmor warning

### DIFF
--- a/.github/workflows/test-mise.yml
+++ b/.github/workflows/test-mise.yml
@@ -23,6 +23,7 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           install: false
+          cache: false
 
       - name: Install mika with mise
         # note: the mise config in the repo might apply hooks


### PR DESCRIPTION
# ci(test-mise): disable mise cache to fix zizmor warning

```sh
$ w zizmor .github/workflows/
[Interactive] q: quit, p: pause/unpause, r: restart
[Running: zizmor .github/workflows/]
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed .github/workflows/docs.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/lint.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/release-mika.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/style.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/test-mise.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/test-rust.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/test.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/zizmor.yml
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> .github/workflows/test-mise.yml:23:9
   |
 3 | / on:
 4 | |   pull_request: ~
 5 | |   push:
 6 | |     branches:
 7 | |       - main
 8 | |   release:
 9 | |     types: [published]
   | |______________________- generally used when publishing artifacts generated at runtime
...
23 |           uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

18 findings (17 suppressed, 1 unsafe fixes): 0 informational, 0 low, 0 medium, 1 high
[Command exited with 14, lasted 208ms]
```

---

# Pull request stack

- 👉🏻 **[#1289](https://github.com/mikavilpas/dotfiles/pull/1289)** | ci(test-mise): disable mise cache to fix zizmor warning 👈🏻