### PR TITLE
fix(mika): main->main PRs from forks prevent branch-summary

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -116,7 +116,11 @@ customCommands:
 
       if [[ "$REMOTE_URL" == *"github"* || "$REMOTE_URL" == *"ghe.com"* ]]; then
         echo "Updating PR description for $BRANCH on GitHub"
-        STACK_SUMMARY=$(gh pr list --json number,title,headRefName,baseRefName,state,url | mika pr-stack-summary - --branch "$BRANCH")
+        # Exclude PRs from other forks: they are not part of our own stack, and a
+        # fork PR opened from the fork's default branch reports its head as the
+        # bare branch name (e.g. `main`), colliding with our `main`, breaking the
+        # `mika` stack tracking.
+        STACK_SUMMARY=$(gh pr list --json number,title,headRefName,baseRefName,state,url,isCrossRepository --jq '[.[] | select(.isCrossRepository == false)]' | mika pr-stack-summary - --branch "$BRANCH")
         SUMMARY="$(printf '%s\n\n---\n\n# Pull request stack\n\n%s' "$SUMMARY" "$STACK_SUMMARY")"
         SUMMARY="$(echo "$SUMMARY" | prettier --no-config --parser markdown --prose-wrap never)"
         gh pr edit "$BRANCH" --body="$SUMMARY" --add-assignee="@me"

--- a/scripts/.mise.toml
+++ b/scripts/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
 "github:mitsuhiko/insta" = { version = "1.48.0", exe = "cargo-insta" }
+"aqua:rust-lang/rust-analyzer" = "2026-06-29"

--- a/scripts/scripts/src/github/github_prs/pr_stack.rs
+++ b/scripts/scripts/src/github/github_prs/pr_stack.rs
@@ -228,4 +228,48 @@ mod tests {
 
         Ok(())
     }
+
+    /// A fork opening a PR from its own default branch reports the head as the
+    /// bare branch name (e.g. `main`) with no owner qualifier, so it collides
+    /// with our own `main`. Such a `main` -> `main` PR must not be treated as the
+    /// parent of every PR based on `main`, which would leave the tree rootless
+    /// and make every real branch look like it has no open PR.
+    #[test]
+    fn test_self_referential_fork_pr_does_not_poison_the_stack()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let url = |n: u64| format!("https://github.com/acme/webapp/pull/{n}");
+        let pr = |number: u64, title: &str, head: &str, base: &str| PullRequest {
+            number,
+            title: title.to_string(),
+            url: url(number),
+            head_ref_name: head.to_string(),
+            base_ref_name: base.to_string(),
+            is_draft: false,
+        };
+
+        let prs = Vec::from([
+            pr(
+                2031,
+                "feat: send to quickfix list",
+                "send-to-quickfix-list",
+                "main",
+            ),
+            // cross-repo PR from a fork opened from the fork's own `main`
+            pr(2030, "fix: honor winborder settings", "main", "main"),
+            pr(1969, "fix: suppress keybindings", "winsplit", "main"),
+        ]);
+
+        // Before the fix this errored with "Current branch '...' is not the head
+        // branch of any open PR." even though PR #2031 clearly exists.
+        let output = pr_stack::format_pr_stack_as_markdown(prs, "send-to-quickfix-list")?;
+        assert_eq!(
+            output,
+            format!(
+                "- 👉🏻 **[#2031]({})** | feat: send to quickfix list 👈🏻",
+                url(2031),
+            )
+        );
+
+        Ok(())
+    }
 }

--- a/scripts/scripts/src/github/github_prs/pr_tree.rs
+++ b/scripts/scripts/src/github/github_prs/pr_tree.rs
@@ -53,6 +53,15 @@ pub(crate) fn treeify_prs(prs: Vec<PullRequest>) -> Result<TreeifyResult> {
     }
     let mut head_to_idx: HashMap<&str, usize> = HashMap::new();
     for (idx, pr) in prs.iter().enumerate() {
+        // If there is a PR from a fork-main->main, ignore it.
+        //
+        // These are never a legitimate parent in a stack. In practice they appear when a fork opens
+        // a PR from its own default branch: `gh pr list` reports the head as the bare branch name
+        // (e.g. `main`) with no owner qualifier, so a fork's `main` -> `main` PR collides with our
+        // own `main`.
+        if pr.head_ref_name == pr.base_ref_name {
+            continue;
+        }
         head_to_idx.insert(&pr.head_ref_name, idx);
     }
     let mut nodes: Vec<PrNode> = prs


### PR DESCRIPTION
# chore(scripts): mise installs rust-analyzer

# fix(lazygit): ignore PRs from forks when generating stack summary

I don't need this functionality at all right now, better ignore it explicitly than to have it blow up later.

# fix(mika): main->main PRs from forks prevent branch-summary

---

# Pull request stack

- 👉🏻 **[#1379](https://github.com/mikavilpas/dotfiles/pull/1379)** | fix(mika): main->main PRs from forks prevent branch-summary 👈🏻