### PR TITLE
ci(perf): don't install unnecessary deps for simple checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,4 +41,6 @@ jobs:
           node-version-file: .nvmrc
           cache: "pnpm"
       - run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: "0"
       - run: pnpm run lint

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
-      - run: pnpm install
+      - run: pnpm install --filter @dotfiles/root
       - run: pnpm format:check
 
   stylua:


### PR DESCRIPTION
# ci(perf): disable cypress install binary in lint workflow

https://docs.cypress.io/app/references/advanced-installation allows specifying `CYPRESS_INSTALL_BINARY=0` to skip downloading the Cypress binary.

# ci(perf): don't install unnecessary deps when checking formatting

It currently installs cypress (the test runner, huge)

---

# Pull request stack

- 👉🏻 **[#1381](https://github.com/mikavilpas/dotfiles/pull/1381)** | ci(perf): don't install unnecessary deps for simple checks 👈🏻