### PR TITLE
fix(mika): gitlab mr_stack summary includes MR title again

### DIFF
--- a/scripts/Cargo.lock
+++ b/scripts/Cargo.lock
@@ -1380,7 +1380,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scripts"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/scripts/scripts/Cargo.toml
+++ b/scripts/scripts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scripts"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 
 [dependencies]

--- a/scripts/scripts/src/gitlab/gitlab_mrs/mr_stack.rs
+++ b/scripts/scripts/src/gitlab/gitlab_mrs/mr_stack.rs
@@ -58,10 +58,24 @@ fn format_mr_stack(
     // Indentation
     let indent = "  ".repeat(depth.0);
 
+    // Clean up the title by removing any "Draft: " prefix that GitLab adds
+    let title_display = mr
+        .title
+        .strip_prefix("Draft: ")
+        .or_else(|| mr.title.strip_prefix("Draft:"))
+        .or_else(|| mr.title.strip_prefix("WIP: "))
+        .unwrap_or(&mr.title);
+
     if is_current {
-        output.push_str(&format!("{}- 👉🏻 {} 👈🏻\n", indent, mr.web_url));
+        output.push_str(&format!(
+            "{}- 👉🏻 **[!{}]({})** | {} 👈🏻\n",
+            indent, mr.iid, mr.web_url, title_display
+        ));
     } else {
-        output.push_str(&format!("{}- {}\n", indent, mr.web_url));
+        output.push_str(&format!(
+            "{}- [!{}]({}) | {}\n",
+            indent, mr.iid, mr.web_url, title_display
+        ));
     }
 
     // Sort children by iid ascending and recurse
@@ -118,33 +132,30 @@ mod tests {
         assert_eq!(
             output_from_root,
             [
-                "- 👉🏻 https://gitlab.example.com/acme/webapp/-/merge_requests/101 👈🏻",
-                "  - https://gitlab.example.com/acme/webapp/-/merge_requests/102",
-                "    - https://gitlab.example.com/acme/webapp/-/merge_requests/103",
-            ]
-            .join("\n")
+                "- 👉🏻 **[!101](https://gitlab.example.com/acme/webapp/-/merge_requests/101)** | feat: base feature 👈🏻",
+                "  - [!102](https://gitlab.example.com/acme/webapp/-/merge_requests/102) | feat: dependent feature",
+                "    - [!103](https://gitlab.example.com/acme/webapp/-/merge_requests/103) | fix: bug in dependent feature",
+            ].join("\n")
         );
 
         let output_from_middle = mr_stack::format_mr_stack_as_markdown(mrs.clone(), second_branch)?;
         assert_eq!(
             output_from_middle,
             [
-                "- https://gitlab.example.com/acme/webapp/-/merge_requests/101",
-                "  - 👉🏻 https://gitlab.example.com/acme/webapp/-/merge_requests/102 👈🏻",
-                "    - https://gitlab.example.com/acme/webapp/-/merge_requests/103",
-            ]
-            .join("\n")
+                "- [!101](https://gitlab.example.com/acme/webapp/-/merge_requests/101) | feat: base feature",
+                "  - 👉🏻 **[!102](https://gitlab.example.com/acme/webapp/-/merge_requests/102)** | feat: dependent feature 👈🏻",
+                "    - [!103](https://gitlab.example.com/acme/webapp/-/merge_requests/103) | fix: bug in dependent feature",
+            ].join("\n")
         );
 
         let output_from_leaf = mr_stack::format_mr_stack_as_markdown(mrs, "feature-103")?;
         assert_eq!(
             output_from_leaf,
             [
-                "- https://gitlab.example.com/acme/webapp/-/merge_requests/101",
-                "  - https://gitlab.example.com/acme/webapp/-/merge_requests/102",
-                "    - 👉🏻 https://gitlab.example.com/acme/webapp/-/merge_requests/103 👈🏻",
-            ]
-            .join("\n")
+                "- [!101](https://gitlab.example.com/acme/webapp/-/merge_requests/101) | feat: base feature",
+                "  - [!102](https://gitlab.example.com/acme/webapp/-/merge_requests/102) | feat: dependent feature",
+                "    - 👉🏻 **[!103](https://gitlab.example.com/acme/webapp/-/merge_requests/103)** | fix: bug in dependent feature 👈🏻",
+            ].join("\n")
         );
 
         Ok(())
@@ -191,10 +202,10 @@ mod tests {
             output,
             format!(
                 "\
-- {}
-  - 👉🏻 {} 👈🏻
-    - {}
-  - {}",
+- [!101]({}) | feat: base feature
+  - 👉🏻 **[!102]({})** | feat: add API layer 👈🏻
+    - [!103]({}) | feat: add tests for API
+  - [!104]({}) | feat: docs for base",
                 url(101),
                 url(102),
                 url(103),
@@ -208,8 +219,8 @@ mod tests {
             output,
             format!(
                 "\
-- {}
-  - 👉🏻 {} 👈🏻",
+- [!105]({}) | chore: CI setup
+  - 👉🏻 **[!106]({})** | chore: add linting 👈🏻",
                 url(105),
                 url(106),
             )
@@ -221,10 +232,10 @@ mod tests {
             output,
             format!(
                 "\
-- 👉🏻 {} 👈🏻
-  - {}
-    - {}
-  - {}",
+- 👉🏻 **[!101]({})** | feat: base feature 👈🏻
+  - [!102]({}) | feat: add API layer
+    - [!103]({}) | feat: add tests for API
+  - [!104]({}) | feat: docs for base",
                 url(101),
                 url(102),
                 url(103),

--- a/scripts/scripts/tests/mika_tests.rs
+++ b/scripts/scripts/tests/mika_tests.rs
@@ -401,9 +401,9 @@ fn mr_stack_summary_can_process_test_data() -> Result<(), Box<dyn std::error::Er
     assert_eq!(
         output,
         [
-            "- 👉🏻 https://gitlab.example.com/my-group/my-project/-/merge_requests/101 👈🏻",
-            "  - https://gitlab.example.com/my-group/my-project/-/merge_requests/102",
-            "    - https://gitlab.example.com/my-group/my-project/-/merge_requests/103",
+            "- 👉🏻 **[!101](https://gitlab.example.com/my-group/my-project/-/merge_requests/101)** | Set up authentication module 👈🏻",
+            "  - [!102](https://gitlab.example.com/my-group/my-project/-/merge_requests/102) | Implement user profile page",
+            "    - [!103](https://gitlab.example.com/my-group/my-project/-/merge_requests/103) | Add input validation to user form",
             "",
         ]
         .join("\n")
@@ -684,9 +684,9 @@ fn mr_stack_summary_defaults_to_current_branch_if_not_given()
     assert_eq!(
         output,
         [
-            "- https://gitlab.example.com/my-group/my-project/-/merge_requests/101",
-            "  - 👉🏻 https://gitlab.example.com/my-group/my-project/-/merge_requests/102 👈🏻",
-            "    - https://gitlab.example.com/my-group/my-project/-/merge_requests/103",
+            "- [!101](https://gitlab.example.com/my-group/my-project/-/merge_requests/101) | Set up authentication module",
+            "  - 👉🏻 **[!102](https://gitlab.example.com/my-group/my-project/-/merge_requests/102)** | Implement user profile page 👈🏻",
+            "    - [!103](https://gitlab.example.com/my-group/my-project/-/merge_requests/103) | Add input validation to user form",
             "",
         ]
         .join("\n")


### PR DESCRIPTION
# version(mika): 1.4.1

# fix(mika): gitlab mr_stack summary includes MR title again

Looks like only github renders that in, but gitlab does not. Put it back to fix the formatting.

---

# Pull request stack

- 👉🏻 https://github.com/mikavilpas/dotfiles/pull/1424 👈🏻