### PR TITLE
ci: remove test bin path export hack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,26 +62,11 @@ jobs:
           mise_toml: |
             [tools]
             lazygit = "${{ env.LAZYGIT_VERSION }}"
-          # Use the same tool identifiers as .config/mise/config.toml so the
-          # shims and the config agree on the backend. `delta` (registry ->
-          # aqua:dandavison/delta) matches the config; `github:dandavison/delta`
-          # would install a different backend that the `delta` shim can't
-          # resolve ("No version is set for shim: delta").
           # prettier-ignore
           install_args: >-
             aqua:fish-shell/fish-shell
             delta
             lazygit@${{ env.LAZYGIT_VERSION }}
-
-      # mise-action v4.2.1 no longer exports the tools' install-dir PATH
-      # (jdx/mise-action#556), so the tui-sandbox test terminal can no longer
-      # find lazygit/fish/delta. Export the bin paths ourselves so this does
-      # not depend on the action's PATH behavior. GITHUB_PATH is inherited by
-      # the spawned test terminal.
-      - name: Expose test tools to the sandbox terminal
-        run:
-          mise bin-paths lazygit aqua:fish-shell/fish-shell delta >>
-          "$GITHUB_PATH"
 
       - name: Verify installed tools work
         run: |

--- a/integration-tests/cypress/e2e/lazygit.cy.ts
+++ b/integration-tests/cypress/e2e/lazygit.cy.ts
@@ -44,11 +44,9 @@ describe("lazygit", () => {
 
     // enter the branch pane and wait for the branch to be selected
 
+    cy.contains("HEAD -> main").should("not.exist")
     cy.typeIntoTerminal("3")
-    textIsVisibleWithBackgroundColor(
-      "main",
-      rgbify(flavors.macchiato.colors.crust.rgb),
-    )
+    cy.contains("HEAD -> main")
 
     // create a backup branch
     cy.typeIntoTerminal("?")
@@ -71,11 +69,9 @@ describe("lazygit", () => {
     cy.contains("Donate")
 
     // enter the commits pane and wait for the commit to be selected
+    cy.contains("insertions(+)").should("not.exist")
     cy.typeIntoTerminal("4")
-    textIsVisibleWithBackgroundColor(
-      "initial commit",
-      rgbify(flavors.macchiato.colors.crust.rgb),
-    )
+    cy.contains("insertions(+)")
 
     cy.typeIntoTerminal("X")
     cy.contains("Copy selected commits to clipboard")


### PR DESCRIPTION
# ci: remove test bin path export hack

This should now be upstreamed to tui-sandbox and no longer needed here.

---

# Pull request stack

- https://github.com/mikavilpas/dotfiles/pull/1427
  - 👉🏻 https://github.com/mikavilpas/dotfiles/pull/1428 👈🏻